### PR TITLE
Adjusts the method used to combine `title` and `md` in addTitleToMarkdown

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -153,7 +153,8 @@ function addTitleToMarkdown(md, title) {
     const frontmatter = match[0];
     return `${frontmatter}\n# ${title}\n${md.substr(frontmatter.length)}`;
   } else {
-    return `# ${title}\n${md}`;
+    const body = md.match(/^.*$/m)[0].length === 0 ? `\n${md}` : `\n\n${md}`;
+    return `# ${title}${body}`;
   }
 }
 

--- a/lib/index.js.flow
+++ b/lib/index.js.flow
@@ -131,7 +131,8 @@ export function addTitleToMarkdown(md: string, title: string) {
     const frontmatter = match[0]
     return `${frontmatter}\n# ${title}\n${md.substr(frontmatter.length)}`
   } else {
-    return `# ${title}\n${md}`
+    const body = md.match(/^.*$/m)[0].length === 0 ? `\n${md}` : `\n\n${md}`
+    return `# ${title}${body}`
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -131,7 +131,8 @@ export function addTitleToMarkdown(md: string, title: string) {
     const frontmatter = match[0]
     return `${frontmatter}\n# ${title}\n${md.substr(frontmatter.length)}`
   } else {
-    return `# ${title}\n${md}`
+    const body = md.match(/^.*$/m)[0].length === 0 ? `\n${md}` : `\n\n${md}`
+    return `# ${title}${body}`
   }
 }
 


### PR DESCRIPTION
The current implementation of `addTitleToMarkdown` inserts a single `\n` between  `title` and `md` when creating the combined markdown.  This is correct if the first line in `md` is blank.  But when `md` has text on the first line, the `title` and `md` will run together (without a line separating them), in the combined markdown .

The solution it to use a conditional to prepend a number of line-returns based on the contents of the first line in `md`.
- If its first line is an empty line, only one `\n` is needed.  
- If its first line has text on it, then `\n\n` is required to ensure a blank line between the title and content. 

This can be determined by inspecting the `length` of the first line in `md`
- If the length is zero, it's an empty line, and only one `\n` is needed
- otherwise, the first line has text on it and `\n\n` should be used

```js
    // from line 134-135 of index.js, md contains the value of note.body
    const body = md.match(/^.*$/m)[0].length === 0 ? `\n${md}` : `\n\n${md}`
    return `# ${title}${body}`
```

Note: I've been using a variation of addTitleToMarkdown with these proposed change in my [export-by-tag](https://github.com/robertpeteuil/inkdrop-export-by-tag) plugin and its working perfectly.